### PR TITLE
Fixed ref to WPFExtensions.dll in proj file

### DIFF
--- a/SeeGitApp/SeeGitApp.csproj
+++ b/SeeGitApp/SeeGitApp.csproj
@@ -84,9 +84,8 @@
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
-    <Reference Include="WPFExtensions, Version=1.0.3437.34043, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>Lib\WPFExtensions.dll</HintPath>
+    <Reference Include="WPFExtensions">
+      <HintPath>..\Lib\WPFExtensions.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Previously the reference didn't point to the version of the file in the
lib folder. If WPFExtensions.dll was not in the GAC the project would not
compile. This changes the ref to always pick up the version of
WPFExtensions.dll in the lib folder.
