### PR TITLE
Operator overloads

### DIFF
--- a/SeeGitApp/Models/CommitEdge.cs
+++ b/SeeGitApp/Models/CommitEdge.cs
@@ -61,6 +61,7 @@ namespace SeeGit
 
         public static bool operator ==(CommitEdge edge, CommitEdge other)
         {
+            if (ReferenceEquals(edge, other)) return true;
             if (ReferenceEquals(edge, null)) return false;
             return edge.Equals(other);
         }

--- a/SeeGitApp/Models/CommitVertex.cs
+++ b/SeeGitApp/Models/CommitVertex.cs
@@ -57,6 +57,7 @@ namespace SeeGit
 
         public static bool operator ==(CommitVertex commit, CommitVertex other)
         {
+            if (ReferenceEquals(commit, other)) return true;
             if (ReferenceEquals(commit, null)) return false;
             return commit.Equals(other);
         }


### PR DESCRIPTION
Hi - I added a minor fix to the nullity checks in CommitVertex.cs and CommitEdge.cs - I was crashing on some local git repos that had been cloned from svn.

Thanks!
