### PR TITLE
Added Object::Equals override to CommitVertex 

### DIFF
--- a/SeeGitApp/Models/CommitVertex.cs
+++ b/SeeGitApp/Models/CommitVertex.cs
@@ -44,6 +44,11 @@ namespace SeeGit
             return string.Format("{0}: {1}", ShortSha, Message);
         }
 
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as CommitVertex);
+        }
+
         public override int GetHashCode()
         {
             unchecked


### PR DESCRIPTION
This was actually being reported as a compiler warning because the CommitVertex class already overrides the equality/inequality operator as well as implmenting the explicit IEquatable<T>, however it did not provide an implementation for Object::Equals. I overrode and provided a very simple implementation that softcasts the obj to CommitVertex and then delegates to the existing IEquatable<T>::Equals implementation.
