### PR TITLE
Added NotifyPropertyChanged base class

### DIFF
--- a/SeeGitApp/Bases/NotifyPropertyChanged.cs
+++ b/SeeGitApp/Bases/NotifyPropertyChanged.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.ComponentModel;
+
+namespace SeeGit
+{
+    public abstract class NotifyPropertyChanged : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected void RaisePropertyChanged(string propertyNane)
+        {
+            var handler = PropertyChanged;
+
+            if(handler != null)
+                handler(this,new PropertyChangedEventArgs(propertyNane));
+        }
+
+        protected void RaisePropertyChanged<T>(Expression<Func<T>> propertyExpresssion)
+        {
+            var propertyName = ExtractPropertyName(propertyExpresssion);
+            RaisePropertyChanged(propertyName);
+        }
+
+        private string ExtractPropertyName<T>(Expression<Func<T>> propertyExpresssion)
+        {
+            if (propertyExpresssion == null)
+            {
+                throw new ArgumentNullException("propertyExpresssion");
+            }
+
+            var memberExpression = propertyExpresssion.Body as MemberExpression;
+            if (memberExpression == null)
+            {
+                throw new ArgumentException("propertyExpresssion");
+            }
+
+            var property = memberExpression.Member as PropertyInfo;
+            if (property == null)
+            {
+                throw new ArgumentException("propertyExpresssion");
+            }
+
+            return memberExpression.Member.Name;
+        }
+    }
+}

--- a/SeeGitApp/Models/CommitVertex.cs
+++ b/SeeGitApp/Models/CommitVertex.cs
@@ -12,7 +12,7 @@ namespace SeeGit
             Sha = sha;
             Message = message;
             Branches = new BranchCollection();
-            Branches.CollectionChanged += (o, e) => NotifyPropertyChanged("HasBranches");
+            Branches.CollectionChanged += (o, e) => RaisePropertyChanged(() => HasBranches);
         }
 
         public string Sha { get; private set; }

--- a/SeeGitApp/Models/GitObject.cs
+++ b/SeeGitApp/Models/GitObject.cs
@@ -1,8 +1,6 @@
-﻿using System.ComponentModel;
-
-namespace SeeGit
+﻿namespace SeeGit
 {
-    public abstract class GitObject<T> : INotifyPropertyChanged
+    public abstract class GitObject<T> : NotifyPropertyChanged
     {
         public abstract override int GetHashCode();
 
@@ -16,14 +14,6 @@ namespace SeeGit
 
         public abstract bool Equals(T other);
 
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        protected void NotifyPropertyChanged(string info)
-        {
-            if (PropertyChanged != null)
-            {
-                PropertyChanged(this, new PropertyChangedEventArgs(info));
-            }
-        }
+        
     }
 }

--- a/SeeGitApp/SeeGitApp.csproj
+++ b/SeeGitApp/SeeGitApp.csproj
@@ -93,6 +93,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="Bases\NotifyPropertyChanged.cs" />
     <Compile Include="Converters\InverseBooleanConverter.cs" />
     <Compile Include="Extensions\CommitTemplatedAdorner.cs" />
     <Compile Include="Extensions\CommitAdornerBehavior.cs" />

--- a/SeeGitApp/ViewModels/MainWindowViewModel.cs
+++ b/SeeGitApp/ViewModels/MainWindowViewModel.cs
@@ -1,11 +1,10 @@
 ﻿using System;
-using System.ComponentModel;
 using System.IO;
 using System.Windows.Threading;
 
 namespace SeeGit
 {
-    public class MainWindowViewModel : INotifyPropertyChanged
+    public class MainWindowViewModel : NotifyPropertyChanged
     {
         private RepositoryGraph _graph;
 
@@ -28,7 +27,7 @@ namespace SeeGit
             set
             {
                 _layoutAlgorithmType = value;
-                NotifyPropertyChanged("LayoutAlgorithmType");
+                RaisePropertyChanged(() => LayoutAlgorithmType);
             }
         }
 
@@ -39,7 +38,7 @@ namespace SeeGit
             {
                 _graph = value;
                 LayoutAlgorithmType = _graph.LayoutAlgorithmType;
-                NotifyPropertyChanged("Graph");
+                RaisePropertyChanged(() => Graph);
             }
         }
 
@@ -77,16 +76,6 @@ namespace SeeGit
         public void Refresh()
         {
             Graph = _graphBuilder.Graph();
-        }
-
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        private void NotifyPropertyChanged(String info)
-        {
-            if (PropertyChanged != null)
-            {
-                PropertyChanged(this, new PropertyChangedEventArgs(info));
-            }
         }
     }
 }


### PR DESCRIPTION
Added NotifyPropertyChanged base class to replace individual INotifyPropertyChanged implementations. Updated property setters where relevant.

I added the class to a new solution folder called "Bases" as it didn't seem to fit in to any of the existing folders.
