### PR TITLE
Equals overrides cleanup and execution of XUnit tests on build

### DIFF
--- a/SeeGitApp/Models/CommitEdge.cs
+++ b/SeeGitApp/Models/CommitEdge.cs
@@ -36,10 +36,7 @@ namespace SeeGit
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != typeof (CommitEdge)) return false;
-            return Equals((CommitEdge)obj);
+            return this.Equals(obj as CommitEdge);
         }
 
         public bool Equals(CommitEdge other)
@@ -61,8 +58,6 @@ namespace SeeGit
 
         public static bool operator ==(CommitEdge edge, CommitEdge other)
         {
-            if (ReferenceEquals(edge, other)) return true;
-            if (ReferenceEquals(edge, null)) return false;
             return edge.Equals(other);
         }
 

--- a/SeeGitApp/Models/CommitVertex.cs
+++ b/SeeGitApp/Models/CommitVertex.cs
@@ -44,11 +44,6 @@ namespace SeeGit
             return string.Format("{0}: {1}", ShortSha, Message);
         }
 
-        public override bool Equals(object obj)
-        {
-            return this.Equals(obj as CommitVertex);
-        }
-
         public override int GetHashCode()
         {
             unchecked
@@ -62,14 +57,12 @@ namespace SeeGit
 
         public static bool operator ==(CommitVertex commit, CommitVertex other)
         {
-            if (ReferenceEquals(commit, other)) return true;
-            if (ReferenceEquals(commit, null)) return false;
             return commit.Equals(other);
         }
 
         public static bool operator !=(CommitVertex commit, CommitVertex other)
         {
-            return !(commit == other);
+            return !commit.Equals(other);
         }
     }
 }

--- a/SeeGitApp/Models/GitObject.cs
+++ b/SeeGitApp/Models/GitObject.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Diagnostics;
 
 namespace SeeGit
 {
@@ -8,9 +9,7 @@ namespace SeeGit
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != typeof (T)) return false;
+            if (!(obj is T)) return false;
             return Equals((T)obj);
         }
 

--- a/UnitTests/Models/CommitEdgeTests.cs
+++ b/UnitTests/Models/CommitEdgeTests.cs
@@ -16,6 +16,7 @@ namespace UnitTests.Models
                                            new CommitVertex("sha-parent", "another parent commit"));
 
                 Assert.True(edge.Equals(other));
+                Assert.True(object.Equals(edge, other));
             }
 
             [Fact]
@@ -27,6 +28,7 @@ namespace UnitTests.Models
                                            new CommitVertex("sha-parent", "another parent commit"));
 
                 Assert.False(edge.Equals(other));
+                Assert.False(object.Equals(edge, other));
             }
 
             [Fact]
@@ -36,6 +38,7 @@ namespace UnitTests.Models
                                           new CommitVertex("sha-parent", "parent commit"));
 
                 Assert.False(edge.Equals(null));
+                Assert.False(object.Equals(edge, null));
             }
         }
 

--- a/UnitTests/Models/CommitVertexTests.cs
+++ b/UnitTests/Models/CommitVertexTests.cs
@@ -27,6 +27,7 @@ namespace UnitTests.Models
                 var other = new CommitVertex("sha", "doesn't matter");
 
                 Assert.True(commit.Equals(other));
+                Assert.True(object.Equals(commit, other));
             }
 
             [Fact]
@@ -36,12 +37,17 @@ namespace UnitTests.Models
                 var other = new CommitVertex("sha2", "doesn't matter");
 
                 Assert.False(commit.Equals(other));
+                Assert.False(object.Equals(commit, other));
             }
 
             [Fact]
             public void ReturnsFalseWhenComparedToNull()
             {
-                Assert.False(new CommitVertex("sha", "message").Equals(null));
+                var commit = new CommitVertex("sha", "message");
+                CommitVertex other = null;
+
+                Assert.False(commit.Equals(other));
+                Assert.False(object.Equals(commit, other));
             }
         }
 

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <RunXUnitTests>true</RunXUnitTests>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -74,7 +75,14 @@
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>
-  <Target Name="AfterBuild">
-  </Target>
   -->
+  <ItemGroup>
+    <PathToXUnit Include="..\packages\xunit*\lib\xunit.runner.msbuild.dll">
+      <InProject>false</InProject>
+    </PathToXUnit>
+  </ItemGroup>
+  <UsingTask AssemblyFile="@(PathToXUnit)" TaskName="Xunit.Runner.MSBuild.xunit" />
+  <Target Name="AfterBuild">
+    <xunit Assembly="$(OutDir)$(TargetName)$(TargetExt)" Condition="$(RunXUnitTests)==true" />
+  </Target>
 </Project>


### PR DESCRIPTION
- cleaned up implementations of Object::Equals, IEquatable<T>::Equals, ==, != on GitObject, CommitVertex and CommitEdge so that there is one core implementation and all others defer to that internally
- added support for running XUnit as part of the build by importing the XUnit MSBuild task from the \packages dir and executing it when the RunXUnitTests property exists (right now only in the Debug configuration)
