### PR TITLE
Rename main assembly to SeeGit

### DIFF
--- a/SeeGitApp/SeeGitApp.csproj
+++ b/SeeGitApp/SeeGitApp.csproj
@@ -9,7 +9,7 @@
     <OutputType>WinExe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SeeGit</RootNamespace>
-    <AssemblyName>SeeGitApp</AssemblyName>
+    <AssemblyName>SeeGit</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <TargetFrameworkProfile>Client</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>


### PR DESCRIPTION
Previous name of the generated exe was SeeGitApp.exe, now it is SeeGit.exe
