### PR TITLE
Refresh layout right after load

### DIFF
--- a/SeeGitApp/ViewModels/MainWindowViewModel.cs
+++ b/SeeGitApp/ViewModels/MainWindowViewModel.cs
@@ -58,6 +58,8 @@ namespace SeeGit
             Graph = _graphBuilder.Graph();
             LayoutAlgorithmType = "Tree";
 
+            Refresh();
+
             MonitorForRepositoryChanges(gitPath);
         }
 


### PR DESCRIPTION
Previously the layout of the graph was random after one loads an existing
repo. Only when the system detected a first change would the commits be
placed nicely on the surface.
