### PR TITLE
Performance Improvement

### DIFF
--- a/SeeGitApp/Models/RepositoryGraphBuilder.cs
+++ b/SeeGitApp/Models/RepositoryGraphBuilder.cs
@@ -88,15 +88,9 @@ namespace SeeGit
             if (childVertex != null)
             {
                 var edge = new CommitEdge(childVertex, commitVertex);
-                if (!_edges.ContainsKey(edge.Id))
-                {
-                    _graph.AddEdge(edge);
-                    _edges.Add(edge.Id, edge);
-                }
-                else
-                {
-                    return;
-                }
+                if (_edges.ContainsKey(edge.Id)) return;
+                _graph.AddEdge(edge);
+                _edges.Add(edge.Id, edge);
             }
 
             foreach (var parent in commit.Parents)
@@ -110,7 +104,7 @@ namespace SeeGit
             CommitVertex commitVertex;
             if (!_vertices.TryGetValue(commit.Sha, out commitVertex))
             {
-                commitVertex = new CommitVertex(commit.Sha, commit.MessageShort) {Description = commit.Message};
+                commitVertex = new CommitVertex(commit.Sha, commit.MessageShort) { Description = commit.Message };
                 _vertices.Add(commit.Sha, commitVertex);
             }
 


### PR DESCRIPTION
Hey Phil Haack!  I love this project and have found it to be a great tool for visualizing our local Git repos.  I noticed that strarting up the application would take a while, especially if there were a few merged branches.  I added this section of code and compared the results of our local repos along with your SeeGit repo and the visual graph matches.  For your SeeGit repo, AddCommitsToGraph was cut down from 94,199 calls to 108.

Let me know what you think!
