### PR TITLE
Stop the app hanging whenever it tries to highlight anything.

### DIFF
--- a/SeeGitApp/Models/ReachableHighlightAlgorithm.cs
+++ b/SeeGitApp/Models/ReachableHighlightAlgorithm.cs
@@ -77,7 +77,7 @@ namespace SeeGit.Models
             foreach (var outEdge in Controller.Graph.OutEdges(vertex))
             {
                 Controller.SemiHighlightEdge(outEdge, "OutEdge");
-                if (Controller.IsHighlightedVertex(outEdge.Target)) continue;
+                if (Controller.IsSemiHighlightedVertex(outEdge.Target)) continue;
                 Controller.SemiHighlightVertex(outEdge.Target, "Target");
                 HighlightChildren(outEdge.Target);
             }


### PR DESCRIPTION
Currently it's going through every path in the graph rather than just the minimal set, because the check to avoid this is slightly wrong.
Could be the problem described in issue https://github.com/Haacked/SeeGit/issues/13
