### PR TITLE
Fixed up PowerShell script

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,1 +1,1 @@
-Powershell -ExecutionPolicy Unrestricted %~dp0Build-Solution.ps1
+Powershell -ExecutionPolicy Unrestricted "& '"%~dp0Build-Solution.ps1"'"


### PR DESCRIPTION
Fixed up PowerShell command execution to send path as a compact string, not as strings broken down by spaces.

Also, miscellaneous newline at the end of the file.
