### PR TITLE
Fix browsing/monitoring non-git directories

### DIFF
--- a/SeeGitApp/Extensions/ModelExtensions.cs
+++ b/SeeGitApp/Extensions/ModelExtensions.cs
@@ -64,7 +64,7 @@ namespace SeeGit
                     e =>
                     e.ChangeType == WatcherChangeTypes.Created &&
                     e.FullPath.Equals(expectedGitDirectory, StringComparison.OrdinalIgnoreCase))
-                .Throttle(TimeSpan.FromSeconds(1));
+                .Take(1);
         }
 
         public static IObservable<FileSystemEventArgs> CreateGitRepositoryChangesObservable(string path)

--- a/SeeGitApp/ViewModels/MainWindowViewModel.cs
+++ b/SeeGitApp/ViewModels/MainWindowViewModel.cs
@@ -57,25 +57,21 @@ namespace SeeGit
         public void MonitorRepository(string repositoryWorkingPath)
         {
             if (repositoryWorkingPath == null) return;
-            
-            string gitPath = ModelExtensions.GetGitRepositoryPath(repositoryWorkingPath);
-            if (!Directory.Exists(gitPath))
-            {
-                MonitorForRepositoryCreation(repositoryWorkingPath);
-                return;
-            }
 
-            RepositoryPath = repositoryWorkingPath;
+            string gitPath = ModelExtensions.GetGitRepositoryPath(repositoryWorkingPath);
 
             _graphBuilder = _graphBuilderThunk(gitPath);
             RepositoryPath = Directory.GetParent(gitPath).FullName;
-            Graph = _graphBuilder.Graph();
+            var graph = _graphBuilder.Graph();
 
-            if (_graph.VertexCount > 1)
-                _graph.LayoutAlgorithmType = "EfficientSugiyama";
-            Graph = Graph;
+            if (graph.VertexCount > 1)
+                graph.LayoutAlgorithmType = "EfficientSugiyama";
+            Graph = graph;
 
-            MonitorForRepositoryChanges(gitPath);
+            if (!Directory.Exists(gitPath))
+                MonitorForRepositoryCreation(RepositoryPath);
+            else
+                MonitorForRepositoryChanges(gitPath);
         }
 
         private void MonitorForRepositoryCreation(string repositoryWorkingPath)
@@ -92,7 +88,11 @@ namespace SeeGit
 
         public void Refresh()
         {
-            Graph = _graphBuilder.Graph();
+            string gitPath = ModelExtensions.GetGitRepositoryPath(RepositoryPath);
+            if (!Directory.Exists(gitPath))
+                MonitorRepository(RepositoryPath);
+            else
+                Graph = _graphBuilder.Graph();
         }
 
         public bool ToggleSettings()


### PR DESCRIPTION
Update view model when selecting an empty/non-git directory so that UI
refreshes correctly.

Make sure the observable for the git directory creation event gets
disposed after getting one event, so that FileSystemWatchers listening
for creation events don't accumulate if the directory is created more
than once.