### PR TITLE
Fix crash with repository with one commit

### DIFF
--- a/SeeGitApp/Models/RepositoryGraphBuilder.cs
+++ b/SeeGitApp/Models/RepositoryGraphBuilder.cs
@@ -49,7 +49,13 @@ namespace SeeGit
             AddBranchReferences();
             AddHeadReference();
 
-            _graph.LayoutAlgorithmType = App.LayoutAlgorithm;
+            // Efficient Sugiyama crashes if we have a single commit repository. So we start with CompoundFDP.
+            // The original attempt to fix this, 50ca739aaadd7249f864d17cae060b1a27e22029, had a bug where we never
+            // changed the algorithm back to Efficient Sugiyama. This fixes that.
+            _graph.LayoutAlgorithmType = 
+                _graph.VertexCount == 1
+                ? "CompoundFDP"
+                : App.LayoutAlgorithm;
             return _graph;
         }
 
@@ -130,12 +136,11 @@ namespace SeeGit
             // KeyValuePair is faster than a Tuple in this case.
             // We create as many instances as we pass to the AddCommitToGraph.
             Queue<CommitWithChildVertex> queue = new Queue<CommitWithChildVertex>();
-            CommitWithChildVertex commitIter;
             queue.Enqueue(new CommitWithChildVertex(commit, childVertex));
 
             while (queue.Count != 0)
             {
-                commitIter = queue.Dequeue();
+                var commitIter = queue.Dequeue();
                 if (!AddCommitToGraph(commitIter.Key, commitIter.Value))
                     continue;
 

--- a/SeeGitApp/ViewModels/MainWindowViewModel.cs
+++ b/SeeGitApp/ViewModels/MainWindowViewModel.cs
@@ -62,11 +62,8 @@ namespace SeeGit
 
             _graphBuilder = _graphBuilderThunk(gitPath);
             RepositoryPath = Directory.GetParent(gitPath).FullName;
-            var graph = _graphBuilder.Graph();
 
-            if (graph.VertexCount > 1)
-                graph.LayoutAlgorithmType = App.LayoutAlgorithm;
-            Graph = graph;
+            Graph = _graphBuilder.Graph();
 
             if (!Directory.Exists(gitPath))
                 MonitorForRepositoryCreation(RepositoryPath);


### PR DESCRIPTION
Efficient Sugiyama crashes if we have a single commit repository. So we
use "CompoundFDP" when there's only one commit.
The original attempt to fix this,
50ca739aaadd7249f864d17cae060b1a27e22029, had a bug where we never
changed the algorithm back to Efficient Sugiyama. This fixes that.
