### PR TITLE
Make the head label yellow

### DIFF
--- a/SeeGitApp/Views/CommitVertexView.xaml
+++ b/SeeGitApp/Views/CommitVertexView.xaml
@@ -51,12 +51,14 @@
                     <DataTemplate>
                       <Border BorderBrush="Black" BorderThickness="1">
                         <Border.Resources>
-
                           <Style x:Key="branch" TargetType="TextBlock">
                             <Style.Triggers>
-
                               <DataTrigger Binding="{Binding Path=IsHead}" Value="True">
                                 <Setter Property="Background" Value="#00CC00" />
+                                <Setter Property="Foreground" Value="Black" />
+                              </DataTrigger>
+                              <DataTrigger Binding="{Binding Path=Name}" Value="HEAD">
+                                <Setter Property="Background" Value="#FFFFCC" />
                                 <Setter Property="Foreground" Value="Black" />
                               </DataTrigger>
                               <DataTrigger Binding="{Binding Path=IsHead}" Value="False">
@@ -66,7 +68,6 @@
                               <DataTrigger Binding="{Binding Path=IsRemote}" Value="True">
                                 <Setter Property="Background" Value="#BFE5FE" />
                                 <Setter Property="Foreground" Value="Black" />
-
                               </DataTrigger>
                             </Style.Triggers>
                           </Style>


### PR DESCRIPTION
The reference annotation "HEAD" is the same color as a branch annotation. This change colors it yellow to call out that it's not a branch, but something else.