### PR TITLE
Migrate QuickGraph to QuikGraph and GraphSharp to GraphShape.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ post about [structuring unit tests](http://haacked.com/archive/2012/01/01/struct
 
 * [LibGit2Sharp](https://github.com/libgit2/libgit2sharp) - [License: MIT](https://github.com/libgit2/libgit2sharp/blob/master/LICENSE.md) LibGit2Sharp is a thin .Net layer (well... we try to keep it as thin as possible :-) ) wrapping the libgit2 linkable C Git library.
 
-* [QuickGraph](http://quickgraph.codeplex.com/) - [License: Ms-PL](http://quickgraph.codeplex.com/license) QuickGraph provides generic directed/undirected graph datastructures and algorithms for .NET. 
-* [GraphSharp](http://graphsharp.codeplex.com/) - [License: Ms-PL](http://graphsharp.codeplex.com/) Graph# is a graph layout framework. It contains some layout algorithms and a GraphLayout control for WPF applications
+* [QuikGraph](https://github.com/KeRNeLith/QuikGraph/) - [License: Ms-PL](https://github.com/KeRNeLith/QuikGraph/blob/master/LICENSE) QuikGraph provides generic directed/undirected graph data structures and algorithms for .NET.
+* [GraphShape](https://github.com/KeRNeLith/GraphShape/) - [License: MIT](https://github.com/KeRNeLith/GraphShape/blob/master/LICENSE) GraphShape is a graph layout framework. It contains some layout algorithms and a GraphLayout control for WPF applications.
 * [Reactive Extensions](http://msdn.microsoft.com/en-us/data/gg577609) - [License: EULA](http://msdn.microsoft.com/en-us/devlabs/ff394099.aspx) The Reactive Extensions (Rx) is a library for composing asynchronous and event-based programs using observable sequences and LINQ-style query operators. 
 * [WPFExtensions](http://wpfextensions.codeplex.com/) - [License: Ms-PL](http://wpfextensions.codeplex.com/license) Some extensions for the WPF framework. Controls, attached behaviours, helper classes, etc.
 * [Windows&reg; API Code Pack for Microsoft&reg; .NET Framework](http://archive.msdn.microsoft.com/WindowsAPICodePack) - [License: EULA](http://archive.msdn.microsoft.com/WindowsAPICodePack/Project/License.aspx) provides a source code library that can be used to access some features of Windows 7 and Windows Vista from managed code.

--- a/SeeGitApp/App.xaml.cs
+++ b/SeeGitApp/App.xaml.cs
@@ -7,6 +7,6 @@ namespace SeeGit
     /// </summary>
     public class App : Application
     {
-        public const string LayoutAlgorithm = "EfficientSugiyama"; // Others include: "CompoundFDP"
+        public const string LayoutAlgorithm = "Sugiyama"; // Others include: "CompoundFDP"
     }
 }

--- a/SeeGitApp/MainWindow.xaml
+++ b/SeeGitApp/MainWindow.xaml
@@ -2,7 +2,8 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:graphsharp="clr-namespace:GraphSharp.Controls;assembly=GraphSharp.Controls" xmlns:local="clr-namespace:SeeGit"
+        xmlns:graphshape="clr-namespace:GraphShape.Controls;assembly=GraphShape.Controls"
+        xmlns:local="clr-namespace:SeeGit"
         xmlns:zoom="clr-namespace:WPFExtensions.Controls;assembly=WPFExtensions"
         xmlns:view="clr-namespace:SeeGit.Views"
         xmlns:extbehaviour="clr-namespace:WPFExtensions.AttachedBehaviours;assembly=WPFExtensions"
@@ -16,19 +17,19 @@
       </StackPanel>
     </DataTemplate>
 
-    <Style TargetType="{x:Type graphsharp:VertexControl}">
+    <Style TargetType="{x:Type graphshape:VertexControl}">
       <Setter Property="Template">
         <Setter.Value>
-          <ControlTemplate TargetType="{x:Type graphsharp:VertexControl}">
+          <ControlTemplate TargetType="{x:Type graphshape:VertexControl}">
             <view:CommitVertexView Model="{Binding}" />
           </ControlTemplate>
         </Setter.Value>
       </Setter>
       <Setter Property="extbehaviour:DragBehaviour.IsDragEnabled" Value="True" />
       <Setter Property="extbehaviour:DragBehaviour.X"
-              Value="{Binding RelativeSource={RelativeSource Self},Path=(graphsharp:GraphCanvas.X),Mode=TwoWay}" />
+              Value="{Binding RelativeSource={RelativeSource Self},Path=(graphshape:GraphCanvas.X),Mode=TwoWay}" />
       <Setter Property="extbehaviour:DragBehaviour.Y"
-              Value="{Binding RelativeSource={RelativeSource Self},Path=(graphsharp:GraphCanvas.Y),Mode=TwoWay}" />
+              Value="{Binding RelativeSource={RelativeSource Self},Path=(graphshape:GraphCanvas.Y),Mode=TwoWay}" />
     </Style>
   </Window.Resources>
 

--- a/SeeGitApp/Models/CommitEdge.cs
+++ b/SeeGitApp/Models/CommitEdge.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
-using QuickGraph;
+using QuikGraph;
 
 namespace SeeGit
 {

--- a/SeeGitApp/Models/ReachableHighlightAlgorithm.cs
+++ b/SeeGitApp/Models/ReachableHighlightAlgorithm.cs
@@ -1,5 +1,6 @@
-﻿using GraphSharp.Algorithms.Highlight;
-using QuickGraph;
+﻿using System.Linq;
+using GraphShape.Algorithms.Highlight;
+using QuikGraph;
 
 namespace SeeGit.Models
 {
@@ -18,11 +19,11 @@ namespace SeeGit.Models
         private void ClearAllHighlights()
         {
             ClearSemiHighlights();
-            foreach (var vertex in Controller.HighlightedVertices)
+            foreach (var vertex in Controller.HighlightedVertices.ToArray())
             {
                 Controller.RemoveHighlightFromVertex(vertex);
             }
-            foreach (var edge in Controller.HighlightedEdges)
+            foreach (var edge in Controller.HighlightedEdges.ToArray())
             {
                 Controller.RemoveHighlightFromEdge(edge);
             }
@@ -30,11 +31,11 @@ namespace SeeGit.Models
 
         private void ClearSemiHighlights()
         {
-            foreach (var vertex in Controller.SemiHighlightedVertices)
+            foreach (var vertex in Controller.SemiHighlightedVertices.ToArray())
             {
                 Controller.RemoveSemiHighlightFromVertex(vertex);
             }
-            foreach (var edge in Controller.SemiHighlightedEdges)
+            foreach (var edge in Controller.SemiHighlightedEdges.ToArray())
             {
                 Controller.RemoveSemiHighlightFromEdge(edge);
             }

--- a/SeeGitApp/Models/ReachableHighlightAlgorithmFactory.cs
+++ b/SeeGitApp/Models/ReachableHighlightAlgorithmFactory.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
-using GraphSharp.Algorithms.Highlight;
-using QuickGraph;
+using GraphShape.Algorithms.Highlight;
+using QuikGraph;
 
 namespace SeeGit.Models
 {
@@ -11,7 +11,7 @@ namespace SeeGit.Models
     {
         private const string HighlightModeName = "Reachable";
 
-        public IHighlightAlgorithm<TVertex, TEdge, TGraph> CreateAlgorithm(string highlightMode,
+        public IHighlightAlgorithm<TVertex, TEdge> CreateAlgorithm(string highlightMode,
                                                                            IHighlightContext<TVertex, TEdge, TGraph>
                                                                                context,
                                                                            IHighlightController<TVertex, TEdge, TGraph>
@@ -27,10 +27,10 @@ namespace SeeGit.Models
 
         public IHighlightParameters CreateParameters(string highlightMode, IHighlightParameters oldParameters)
         {
-            return new HighlightParameterBase();
+            return new HighlightParameters();
         }
 
-        public string GetHighlightMode(IHighlightAlgorithm<TVertex, TEdge, TGraph> algorithm)
+        public string GetHighlightMode(IHighlightAlgorithm<TVertex, TEdge> algorithm)
         {
             if (algorithm is ReachableHighlightAlgorithm<TVertex, TEdge, TGraph>)
             {

--- a/SeeGitApp/Models/RepositoryGraph.cs
+++ b/SeeGitApp/Models/RepositoryGraph.cs
@@ -1,4 +1,4 @@
-﻿using QuickGraph;
+﻿using QuikGraph;
 
 namespace SeeGit
 {

--- a/SeeGitApp/Models/RepositoryGraphBuilder.cs
+++ b/SeeGitApp/Models/RepositoryGraphBuilder.cs
@@ -49,13 +49,7 @@ namespace SeeGit
             AddBranchReferences();
             AddHeadReference();
 
-            // Efficient Sugiyama crashes if we have a single commit repository. So we start with CompoundFDP.
-            // The original attempt to fix this, 50ca739aaadd7249f864d17cae060b1a27e22029, had a bug where we never
-            // changed the algorithm back to Efficient Sugiyama. This fixes that.
-            _graph.LayoutAlgorithmType = 
-                _graph.VertexCount == 1
-                ? "CompoundFDP"
-                : App.LayoutAlgorithm;
+            _graph.LayoutAlgorithmType = App.LayoutAlgorithm;
             return _graph;
         }
 

--- a/SeeGitApp/Models/RepositoryGraphLayout.cs
+++ b/SeeGitApp/Models/RepositoryGraphLayout.cs
@@ -1,4 +1,4 @@
-﻿using GraphSharp.Controls;
+﻿using GraphShape.Controls;
 using SeeGit.Models;
 
 namespace SeeGit

--- a/SeeGitApp/SeeGitApp.csproj
+++ b/SeeGitApp/SeeGitApp.csproj
@@ -44,11 +44,11 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GraphShape, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\GraphShape.1.0.0\lib\net40\GraphShape.dll</HintPath>
+    <Reference Include="GraphShape, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\GraphShape.1.1.0\lib\net40\GraphShape.dll</HintPath>
     </Reference>
-    <Reference Include="GraphShape.Controls, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\GraphShape.Controls.1.0.0\lib\net40\GraphShape.Controls.dll</HintPath>
+    <Reference Include="GraphShape.Controls, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\GraphShape.Controls.1.1.0\lib\net40\GraphShape.Controls.dll</HintPath>
     </Reference>
     <Reference Include="LibGit2Sharp, Version=0.24.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
       <HintPath>..\packages\LibGit2Sharp.0.24.0\lib\net40\LibGit2Sharp.dll</HintPath>
@@ -63,8 +63,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Windows7APICodePack-Shell.1.1.0.0\lib\Microsoft.WindowsAPICodePack.Shell.dll</HintPath>
     </Reference>
-    <Reference Include="QuikGraph, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\QuikGraph.2.1.0\lib\net40\QuikGraph.dll</HintPath>
+    <Reference Include="QuikGraph, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\QuikGraph.2.2.0\lib\net40\QuikGraph.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/SeeGitApp/SeeGitApp.csproj
+++ b/SeeGitApp/SeeGitApp.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.185\build\LibGit2Sharp.NativeBinaries.props')" />
   <PropertyGroup>
@@ -44,13 +44,11 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GraphSharp, Version=1.0.2.0, Culture=neutral, PublicKeyToken=f9c24778325a6b82, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\GraphSharp.1.1.0.0\lib\net40\GraphSharp.dll</HintPath>
+    <Reference Include="GraphShape, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\GraphShape.1.0.0\lib\net40\GraphShape.dll</HintPath>
     </Reference>
-    <Reference Include="GraphSharp.Controls, Version=1.1.0.0, Culture=neutral, PublicKeyToken=f9c24778325a6b82, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\GraphSharp.1.1.0.0\lib\net40\GraphSharp.Controls.dll</HintPath>
+    <Reference Include="GraphShape.Controls, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\GraphShape.Controls.1.0.0\lib\net40\GraphShape.Controls.dll</HintPath>
     </Reference>
     <Reference Include="LibGit2Sharp, Version=0.24.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
       <HintPath>..\packages\LibGit2Sharp.0.24.0\lib\net40\LibGit2Sharp.dll</HintPath>
@@ -65,18 +63,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Windows7APICodePack-Shell.1.1.0.0\lib\Microsoft.WindowsAPICodePack.Shell.dll</HintPath>
     </Reference>
-    <Reference Include="QuickGraph, Version=3.6.61114.0, Culture=neutral, PublicKeyToken=f3fb40175eec2af3, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.dll</HintPath>
-    </Reference>
-    <Reference Include="QuickGraph.Data">
-      <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.Data.dll</HintPath>
-    </Reference>
-    <Reference Include="QuickGraph.Graphviz">
-      <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.Graphviz.dll</HintPath>
-    </Reference>
-    <Reference Include="QuickGraph.Serialization">
-      <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.Serialization.dll</HintPath>
+    <Reference Include="QuikGraph, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\QuikGraph.2.1.0\lib\net40\QuikGraph.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/SeeGitApp/ViewModels/MainWindowViewModel.cs
+++ b/SeeGitApp/ViewModels/MainWindowViewModel.cs
@@ -10,7 +10,7 @@ namespace SeeGit
         private string _repositoryPath;
 
         private IRepositoryGraphBuilder _graphBuilder;
-        // Tree, LinLog, KK, ISOM, EfficientSugiyama, FR, CompoundFDP, BoundedFR, Circular
+        // Tree, LinLog, KK, ISOM, Sugiyama, FR, CompoundFDP, BoundedFR, Circular, Random
 
         private string _layoutAlgorithmType = "Tree";
         private readonly Dispatcher _uiDispatcher;

--- a/SeeGitApp/packages.config
+++ b/SeeGitApp/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GraphShape" version="1.0.0" targetFramework="net40" />
-  <package id="GraphShape.Controls" version="1.0.0" targetFramework="net40" />
+  <package id="GraphShape" version="1.1.0" targetFramework="net40" />
+  <package id="GraphShape.Controls" version="1.1.0" targetFramework="net40" />
   <package id="LibGit2Sharp" version="0.24.0" targetFramework="net462" />
   <package id="LibGit2Sharp.NativeBinaries" version="1.0.185" targetFramework="net462" />
-  <package id="QuikGraph" version="2.1.0" targetFramework="net40" />
+  <package id="QuikGraph" version="2.2.0" targetFramework="net40" />
   <package id="Rx_Experimental-Main" version="1.1.11111" requireReinstallation="true" />
   <package id="Windows7APICodePack-Core" version="1.1.0.0" targetFramework="net40-Client" />
   <package id="Windows7APICodePack-Shell" version="1.1.0.0" targetFramework="net40-Client" />

--- a/SeeGitApp/packages.config
+++ b/SeeGitApp/packages.config
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GraphSharp" version="1.1.0.0" targetFramework="net40-Client" />
+  <package id="GraphShape" version="1.0.0" targetFramework="net40" />
+  <package id="GraphShape.Controls" version="1.0.0" targetFramework="net40" />
   <package id="LibGit2Sharp" version="0.24.0" targetFramework="net462" />
   <package id="LibGit2Sharp.NativeBinaries" version="1.0.185" targetFramework="net462" />
-  <package id="QuickGraph" version="3.6.61119.7" targetFramework="net40-Client" />
+  <package id="QuikGraph" version="2.1.0" targetFramework="net40" />
   <package id="Rx_Experimental-Main" version="1.1.11111" requireReinstallation="true" />
   <package id="Windows7APICodePack-Core" version="1.1.0.0" targetFramework="net40-Client" />
   <package id="Windows7APICodePack-Shell" version="1.1.0.0" targetFramework="net40-Client" />

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -49,8 +49,8 @@
       <HintPath>..\packages\Moq.4.8.1\lib\net45\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="QuikGraph, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\QuikGraph.2.1.0\lib\net40\QuikGraph.dll</HintPath>
+    <Reference Include="QuikGraph, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\QuikGraph.2.2.0\lib\net40\QuikGraph.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\xunit.runner.msbuild.2.3.1\build\net452\xunit.runner.msbuild.props" Condition="Exists('..\packages\xunit.runner.msbuild.2.3.1\build\net452\xunit.runner.msbuild.props')" />
   <Import Project="..\packages\xunit.core.2.3.1\build\xunit.core.props" Condition="Exists('..\packages\xunit.core.2.3.1\build\xunit.core.props')" />
@@ -45,30 +45,12 @@
       <HintPath>..\packages\Castle.Core.4.2.1\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="GraphSharp, Version=1.0.2.0, Culture=neutral, PublicKeyToken=f9c24778325a6b82, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\GraphSharp.1.1.0.0\lib\net40\GraphSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="GraphSharp.Controls, Version=1.1.0.0, Culture=neutral, PublicKeyToken=f9c24778325a6b82, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\GraphSharp.1.1.0.0\lib\net40\GraphSharp.Controls.dll</HintPath>
-    </Reference>
     <Reference Include="Moq, Version=4.8.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.8.1\lib\net45\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="QuickGraph, Version=3.6.61114.0, Culture=neutral, PublicKeyToken=f3fb40175eec2af3, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.dll</HintPath>
-    </Reference>
-    <Reference Include="QuickGraph.Data">
-      <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.Data.dll</HintPath>
-    </Reference>
-    <Reference Include="QuickGraph.Graphviz">
-      <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.Graphviz.dll</HintPath>
-    </Reference>
-    <Reference Include="QuickGraph.Serialization">
-      <HintPath>..\packages\QuickGraph.3.6.61119.7\lib\net4\QuickGraph.Serialization.dll</HintPath>
+    <Reference Include="QuikGraph, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\QuikGraph.2.1.0\lib\net40\QuikGraph.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/UnitTests/packages.config
+++ b/UnitTests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Castle.Core" version="4.2.1" targetFramework="net46" />
   <package id="Moq" version="4.8.1" targetFramework="net46" />
-  <package id="QuikGraph" version="2.1.0" targetFramework="net40" />
+  <package id="QuikGraph" version="2.2.0" targetFramework="net40" />
   <package id="System.Threading.Tasks.Extensions" version="4.4.0" targetFramework="net46" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net46" requireReinstallation="true" />
   <package id="WPFExtensions" version="1.0.0" targetFramework="net40" />

--- a/UnitTests/packages.config
+++ b/UnitTests/packages.config
@@ -1,9 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.2.1" targetFramework="net46" />
-  <package id="GraphSharp" version="1.1.0.0" targetFramework="net40" />
   <package id="Moq" version="4.8.1" targetFramework="net46" />
-  <package id="QuickGraph" version="3.6.61119.7" targetFramework="net40" />
+  <package id="QuikGraph" version="2.1.0" targetFramework="net40" />
   <package id="System.Threading.Tasks.Extensions" version="4.4.0" targetFramework="net46" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net46" requireReinstallation="true" />
   <package id="WPFExtensions" version="1.0.0" targetFramework="net40" />


### PR DESCRIPTION
Hello,

I updated the quite old QuickGraph and GraphSharp dependencies to respectively QuikGraph and GraphShape.

Those libraries are using modern C# development workflow, have been ported to .NET Core with a wider support in term of targets.
And finally they come with a huge set of unit tests that has helped to debug and fix a lot of issues in both libraries. Some issues were encountered in this project and are now fixed.

Here are the links to both libraries:
- [QuikGraph](https://github.com/KeRNeLith/QuikGraph)
- [GraphShape](https://github.com/KeRNeLith/GraphShape)